### PR TITLE
Support Tensorflow 2

### DIFF
--- a/datasets/prepare_dataset.py
+++ b/datasets/prepare_dataset.py
@@ -4,7 +4,10 @@ from tqdm import tqdm
 import cv2
 import numpy as np
 import json
-import tensorflow as tf
+try:
+    import tensorflow.compat.v1 as tf
+except ImportError:
+    import tensorflow as tf
 from scipy.misc import imresize
 
 

--- a/datasets/prepare_div2k_dataset.py
+++ b/datasets/prepare_div2k_dataset.py
@@ -2,7 +2,10 @@ import os
 import argparse
 from tqdm import tqdm
 import cv2
-import tensorflow as tf
+try:
+    import tensorflow.compat.v1 as tf
+except ImportError:
+    import tensorflow as tf
 
 
 def bytes_feature(value):

--- a/evaluate.py
+++ b/evaluate.py
@@ -1,4 +1,7 @@
-import tensorflow as tf
+try:
+    import tensorflow.compat.v1 as tf
+except ImportError:
+    import tensorflow as tf
 import numpy as np
 import argparse
 import os

--- a/generate_header_and_model.py
+++ b/generate_header_and_model.py
@@ -1,4 +1,7 @@
-import tensorflow as tf
+try:
+    import tensorflow.compat.v1 as tf
+except ImportError:
+    import tensorflow as tf
 import numpy as np
 import argparse
 import os

--- a/models/dataset.py
+++ b/models/dataset.py
@@ -1,4 +1,7 @@
-import tensorflow as tf
+try:
+    import tensorflow.compat.v1 as tf
+except ImportError:
+    import tensorflow as tf
 from collections import OrderedDict
 
 

--- a/models/image_warp.py
+++ b/models/image_warp.py
@@ -1,4 +1,7 @@
-import tensorflow as tf
+try:
+    import tensorflow.compat.v1 as tf
+except ImportError:
+    import tensorflow as tf
 
 
 def image_warp(images, flow, name='image_warp'):

--- a/models/model.py
+++ b/models/model.py
@@ -1,5 +1,8 @@
 from abc import ABC, abstractmethod
-import tensorflow as tf
+try:
+    import tensorflow.compat.v1 as tf
+except ImportError:
+    import tensorflow as tf
 import json
 from .dataset import Dataset
 

--- a/models/model_espcn.py
+++ b/models/model_espcn.py
@@ -1,4 +1,7 @@
-import tensorflow as tf
+try:
+    import tensorflow.compat.v1 as tf
+except ImportError:
+    import tensorflow as tf
 from .model import Model
 
 

--- a/models/model_srcnn.py
+++ b/models/model_srcnn.py
@@ -1,4 +1,7 @@
-import tensorflow as tf
+try:
+    import tensorflow.compat.v1 as tf
+except ImportError:
+    import tensorflow as tf
 from .model import Model
 
 

--- a/models/model_vespcn.py
+++ b/models/model_vespcn.py
@@ -1,4 +1,7 @@
-import tensorflow as tf
+try:
+    import tensorflow.compat.v1 as tf
+except ImportError:
+    import tensorflow as tf
 from .model import Model
 from .image_warp import image_warp
 

--- a/models/model_vsrnet.py
+++ b/models/model_vsrnet.py
@@ -1,4 +1,7 @@
-import tensorflow as tf
+try:
+    import tensorflow.compat.v1 as tf
+except ImportError:
+    import tensorflow as tf
 from .model import Model
 
 

--- a/train.py
+++ b/train.py
@@ -1,4 +1,7 @@
-import tensorflow as tf
+try:
+    import tensorflow.compat.v1 as tf
+except ImportError:
+    import tensorflow as tf
 import argparse
 from tqdm import tqdm
 import os


### PR DESCRIPTION
This PR adds support for Tensorflow 2 by trying to import `tensorflow.compat.v1` and only importing `tensorflow` when the former raises an `ImportError`. This functionality is used in [MIR-MU/ffmpeg-tensorflow](https://github.com/MIR-MU/ffmpeg-tensorflow).